### PR TITLE
Fix credential save retry

### DIFF
--- a/main.py
+++ b/main.py
@@ -166,7 +166,8 @@ def main():
 
         # Re-prompt for credentials and retry
         email, password = prompt_credentials(host)
-        save_credentials(email, password)
+        # Pass the host to ensure save_credentials receives all required args
+        save_credentials(email, password, host)
 
         # Show progress dialog again for retry
         progress_dialog = show_script_running_dialog()


### PR DESCRIPTION
## Summary
- fix call to save_credentials in exception handler
- note why host argument is passed
- run system test after installing dependencies

## Testing
- `pip install -r requirements.txt`
- `python test_setup.py`


------
https://chatgpt.com/codex/tasks/task_b_6883c8c383e88331a1ba06cf688c00ea