### PR TITLE
Fix credential saving retry

### DIFF
--- a/main.py
+++ b/main.py
@@ -166,7 +166,7 @@ def main():
 
         # Re-prompt for credentials and retry
         email, password = prompt_credentials(host)
-        save_credentials(email, password)
+        save_credentials(email, password, host)
 
         # Show progress dialog again for retry
         progress_dialog = show_script_running_dialog()


### PR DESCRIPTION
## Summary
- ensure host is saved when retrying after failed login

## Testing
- `python test_setup.py`

------
https://chatgpt.com/codex/tasks/task_b_6883cad3df1c8331a7678bb4d57084f1